### PR TITLE
✅ test: add unit tests and 👷 ci: add Docker image push to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -104,3 +105,33 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --allow-dirty
+
+  docker:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/atareao/den
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.justfile
+++ b/.justfile
@@ -1,51 +1,47 @@
 user    := "atareao"
 name    := `basename ${PWD}`
-version  := `vampus show`
-
+version := `vampus show`
 
 build:
-    @docker build \
+    @podman build \
         --tag={{user}}/{{name}}:{{version}} \
         --tag={{user}}/{{name}}:latest .
 
 push:
-    @docker image push --all-tags {{user}}/{{name}}
+    @podman image push --all-tags {{user}}/{{name}}
 
 upgrade:
-    #!/bin/fish
+    #!/usr/bin/env bash
+    set -euo pipefail
     vampus upgrade --patch
-    set VERSION $(vampus show)
+    VERSION=$(vampus show)
     cargo update
     git commit -am "Upgrade to version $VERSION"
     git tag -a "$VERSION" -m "Version $VERSION"
-    # clean old docker images
-    docker image list  | grep {{name}} | sort -r | tail -n +5 | awk '{print $3}' | while read id; echo $id; docker rmi $id; end
+    podman image list | grep {{name}} | sort -r | tail -n +5 | awk '{print $3}' | while read -r id; do echo "$id"; podman rmi "$id"; done
     just build push
 
 buildx:
-    #!/usr/bin/env bash
-    #--platform linux/arm/v7,linux/arm64/v8,linux/amd64 \
-    docker buildx build \
-           --push \
-           --platform linux/arm/v7,linux/arm64/v8,linux/amd64 \
-           --tag {{user}}/{{name}}:{{version}} .
+    @podman build \
+        --platform linux/arm/v7,linux/arm64/v8,linux/amd64 \
+        --tag={{user}}/{{name}}:{{version}} \
+        --tag={{user}}/{{name}}:latest .
+    @podman image push --all-tags {{user}}/{{name}}
 
 run:
-    docker run --rm \
-               --init \
-               --name croni \
-               --init \
-               --env_file croni.env \
-               -v ${PWD}/crontab:/crontab \
-               {{user}}/{{name}}:{{version}}
+    podman run --rm \
+        --init \
+        --name den \
+        --env-file den.env \
+        -v ${PWD}/crontab:/crontab \
+        {{user}}/{{name}}:{{version}}
 
 sh:
-    docker run --rm \
-               -it \
-               --name croni \
-               --init \
-               --env-file croni.env \
-               -v ${PWD}/crontab:/crontab \
-               {{user}}/{{name}}:{{version}} \
-               sh
-
+    podman run --rm \
+        -it \
+        --name den \
+        --init \
+        --env-file den.env \
+        -v ${PWD}/crontab:/crontab \
+        {{user}}/{{name}}:{{version}} \
+        sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "57e34be7db1d0210da6ac2dde4236e0177daa321a589715e495e8b2226325f9f"
 dependencies = [
  "amq-protocol",
  "built",
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "cookie-factory",
  "crossbeam-channel",
  "indexmap 1.9.3",
@@ -36,7 +36,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.3.2",
  "snafu",
- "url 2.5.7",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -109,6 +109,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -130,9 +152,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -154,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -176,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cargo-lock"
@@ -189,16 +211,18 @@ dependencies = [
  "semver",
  "serde",
  "toml",
- "url 2.5.7",
+ "url 2.5.8",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -215,6 +239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +256,25 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes 1.12.0",
+ "memchr",
 ]
 
 [[package]]
@@ -247,9 +296,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
- "url 2.5.7",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -263,6 +312,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -338,7 +397,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -349,7 +408,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -377,11 +436,10 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -397,13 +455,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -421,7 +479,7 @@ dependencies = [
  "asynchronous-codec",
  "base64 0.13.1",
  "byteorder",
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "chrono",
  "containers-api",
  "docker-api-stubs",
@@ -433,8 +491,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "thiserror",
- "url 2.5.7",
+ "thiserror 1.0.69",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -448,6 +506,12 @@ dependencies = [
  "serde_json",
  "serde_with",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "encoding_rs"
@@ -494,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -539,6 +603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -581,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -598,38 +668,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -639,7 +709,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -665,13 +734,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -681,24 +752,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.12.1",
+ "http 1.4.2",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -730,9 +803,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -752,18 +825,18 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "itoa",
 ]
 
@@ -773,7 +846,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "http 0.2.12",
  "pin-project-lite",
 ]
@@ -784,8 +857,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.11.0",
- "http 1.4.0",
+ "bytes 1.12.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -794,9 +867,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -819,7 +892,7 @@ version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -838,21 +911,20 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -860,55 +932,37 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http 1.4.2",
+ "hyper 1.10.1",
  "hyper-util",
- "rustls 0.23.35",
- "rustls-pki-types",
+ "rustls 0.23.40",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes 1.11.0",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding 2.3.2",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -955,12 +1009,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -968,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -981,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -995,15 +1050,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1015,15 +1070,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1064,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1085,12 +1140,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1099,7 +1154,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acee673b88a760f5d1f7b2677a90ab797878282ca36ebd0ed8d560361bee9810"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
 ]
 
 [[package]]
@@ -1113,33 +1168,83 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.4",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "once_cell",
+ "cfg-if 1.0.4",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1167,9 +1272,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1177,7 +1282,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall",
 ]
@@ -1190,9 +1295,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1205,9 +1310,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maplit"
@@ -1241,9 +1352,15 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "mime"
@@ -1253,10 +1370,11 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minijinja"
-version = "2.13.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adbe6e92a6ce0fd6c4aac593fdfd3e3950b0f61b1a63aa9731eb6fd85776fa3"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
+ "memo-map",
  "serde",
 ]
 
@@ -1291,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1339,7 +1457,7 @@ dependencies = [
  "rustls 0.19.1",
  "tokio",
  "tokio-rustls 0.22.0",
- "url 2.5.7",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -1360,10 +1478,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1400,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1424,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
@@ -1434,7 +1552,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
@@ -1451,7 +1569,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1459,6 +1577,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
@@ -1553,7 +1677,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1583,20 +1707,14 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -1606,9 +1724,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1620,10 +1738,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1635,10 +1762,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quote"
-version = "1.0.42"
+name = "quinn"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes 1.12.0",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes 1.12.0",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring 0.17.14",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1650,12 +1833,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1672,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1683,45 +1895,45 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "encoding_rs",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding 2.3.2",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.40",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
- "url 2.5.7",
+ "url 2.5.8",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1750,10 +1962,25 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1762,7 +1989,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1784,10 +2011,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1796,20 +2024,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.13.1"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.103.8"
+name = "rustls-platform-verifier"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
  "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -1823,9 +2092,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1838,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -1867,8 +2136,21 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1876,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1886,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -1921,32 +2203,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
+ "zmij",
 ]
 
 [[package]]
@@ -1974,7 +2244,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1983,7 +2253,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2012,16 +2282,17 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -2032,16 +2303,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "slab"
-version = "0.4.11"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snafu"
@@ -2077,12 +2364,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2122,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2148,17 +2435,17 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2202,7 +2489,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2213,7 +2509,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2227,32 +2534,31 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2260,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2270,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2285,40 +2591,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "libc",
- "mio 1.1.1",
+ "mio 1.2.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2338,17 +2634,17 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls 0.23.40",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.12.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2366,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2381,20 +2677,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
- "bytes 1.11.0",
+ "bitflags 2.13.0",
+ "bytes 1.12.0",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -2411,9 +2707,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2428,14 +2724,14 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2454,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2503,9 +2799,9 @@ checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -2547,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna 1.1.0",
@@ -2620,18 +2916,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -2642,22 +2938,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
- "cfg-if 1.0.4",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2665,31 +2958,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2703,6 +3006,15 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring 0.16.20",
  "untrusted 0.7.1",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2769,7 +3081,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2780,7 +3092,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2976,15 +3288,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws2_32-sys"
@@ -3008,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3019,48 +3331,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
+name = "zerocopy"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3069,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3080,11 +3412,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.48", features = ["full"]}
+tokio = { version = "1.52", features = ["full"]}
 futures = "0.3"
 docker-api = "0.14.0"
-reqwest = {version = "0.12", features = ["json"] }
+reqwest = {version = "0.13", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tracing = "0.1.43"
-tracing-subscriber = { version = "0.3.22", features = ["local-time", "env-filter"] }
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["local-time", "env-filter"] }
 gethostname = "1.1"
-minijinja = "2.13.0"
-time = { version = "0.3.44", features = ["serde", "formatting", "parsing"] }
+minijinja = "2.21.0"
+time = { version = "0.3.49", features = ["serde", "formatting", "parsing"] }
 openssl = { version = "0.10", features = ["vendored"] }
 urlencoding = "2.1"
 markdown = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/PKief/vscode-material-icon-theme/ec559a9f6bfd399b82bb44393651661b08aaf7ba/icons/folder-markdown-open.svg" width="100" alt="project-logo">
+  <img src="https://raw.githubusercontent.com/PKief/vscode-material-icon-theme/ec559a9f6bfd399b82bb44393651661b08aaf7ba/icons/folder-markdown-open.svg" width="100" alt="den-logo">
 </p>
 <p align="center">
     <h1 align="center">DEN</h1>
@@ -8,171 +8,167 @@
     <em>Amplify events, empower notifications, elevate observability.</em>
 </p>
 <p align="center">
-	<img src="https://img.shields.io/github/license/atareao/den?style=default&logo=opensourceinitiative&logoColor=white&color=0080ff" alt="license">
-	<img src="https://img.shields.io/github/last-commit/atareao/den?style=default&logo=git&logoColor=white&color=0080ff" alt="last-commit">
-	<img src="https://img.shields.io/github/languages/top/atareao/den?style=default&color=0080ff" alt="repo-top-language">
-	<img src="https://img.shields.io/github/languages/count/atareao/den?style=default&color=0080ff" alt="repo-language-count">
+  <a href="https://crates.io/crates/den">
+    <img src="https://img.shields.io/badge/den-v0.1.3-0080ff?style=flat&logo=rust" alt="version">
+  </a>
+  <a href="https://github.com/atareao/den/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/atareao/den?style=flat&logo=opensourceinitiative&logoColor=white&color=0080ff" alt="license">
+  </a>
+  <a href="https://github.com/atareao/den/releases">
+    <img src="https://img.shields.io/github/v/release/atareao/den?style=flat&logo=github&logoColor=white&color=0080ff" alt="release">
+  </a>
+  <a href="https://github.com/atareao/den/actions">
+    <img src="https://img.shields.io/github/actions/workflow/status/atareao/den/ci.yml?style=flat&logo=githubactions&logoColor=white&color=0080ff" alt="build">
+  </a>
+  <br>
+  <a href="https://hub.docker.com/r/atareao/den">
+    <img src="https://img.shields.io/docker/pulls/atareao/den?style=flat&logo=docker&logoColor=white&color=0080ff" alt="docker-pulls">
+  </a>
+  <a href="https://github.com/atareao/den/stargazers">
+    <img src="https://img.shields.io/github/stars/atareao/den?style=flat&logo=star&logoColor=white&color=0080ff" alt="stars">
+  </a>
+  <a href="https://github.com/atareao/den/network">
+    <img src="https://img.shields.io/github/forks/atareao/den?style=flat&logo=git&logoColor=white&color=0080ff" alt="forks">
+  </a>
+  <a href="https://github.com/atareao/den/blob/main/Cargo.toml">
+    <img src="https://img.shields.io/badge/Rust-2021-0080ff?style=flat&logo=rust&logoColor=white" alt="rust-edition">
+  </a>
+  <a href="https://github.com/atareao/den/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/languages/top/atareao/den?style=flat&logo=rust&logoColor=white&color=0080ff" alt="language">
+  </a>
+  <a href="https://github.com/atareao/den/graphs/contributors">
+    <img src="https://img.shields.io/github/contributors/atareao/den?style=flat&logo=people&logoColor=white&color=0080ff" alt="contributors">
+  </a>
 <p>
-<p align="center">
-	<!-- default option, no dependency badges. -->
-</p>
 
-<br><!-- TABLE OF CONTENTS -->
-<details>
-  <summary>Table of Contents</summary><br>
+<br>
 
-- [ Overview](#-overview)
-- [ Features](#-features)
-- [ Repository Structure](#-repository-structure)
-- [ Modules](#-modules)
-- [ Getting Started](#-getting-started)
-  - [ Installation](#-installation)
-  - [ Usage](#-usage)
-  - [ Tests](#-tests)
-- [ Project Roadmap](#-project-roadmap)
-- [ Contributing](#-contributing)
-- [ License](#-license)
-- [ Acknowledgments](#-acknowledgments)
-</details>
-<hr>
+## Overview
 
-##  Overview
+**DEN** is a lightweight Docker Event Notification daemon written in [Rust](https://www.rust-lang.org/). It listens to the Docker event stream and forwards matching events to your preferred messaging or observability platforms.
 
-A Docker Event Notification
+### Supported Publishers
 
-A very simple app in a Docker to notificate docker events with some Messaging services as,
+| Service       | Protocol     | Use Case              |
+|---------------|-------------|-----------------------|
+| Telegram      | HTTP Bot API| Chat notifications    |
+| Mattermost    | Webhook     | Team messaging        |
+| Discord       | Webhook     | Community alerts      |
+| Slack         | Webhook     | Workplace alerts      |
+| Matrix        | Client-Server API | Decentralized chat|
+| RabbitMQ      | AMQP        | Message queue         |
+| Mosquitto     | MQTT        | IoT / lightweight     |
+| ZincObserve   | HTTP API    | Log aggregation       |
 
-* Telegram
-* Mattermost
-* Discord
-* ZincObeserve
-* Matrix
-* Rabbitmq
-* Mosquitto
+---
 
-### Avoid container monitoring
+## Quick Start
 
-if `monitorize_always=true` all container are monitorized except has those who has the label `es.atareao.den.monitorize=false`. But if `monitorize_always=false` only container with the label `es.atareao.den.monitorize=true` will be monitorized.
+### Docker Compose
 
-So if you set `es.atareao.den.monitorize=false` the container never will be monitorized, also if `monitorize_always=true`
-
-```bash
-docker run --label es.atareao.den.monitorize=false --rm hello-world
+```yaml
+services:
+  den:
+    image: atareao/den:latest
+    container_name: den
+    init: true
+    restart: unless-stopped
+    hostname: co1
+    environment:
+      RUST_LOG: debug
+    volumes:
+      - ./config.yml:/app/config.yml
+      - /var/run/docker.sock:/var/run/docker.sock
 ```
 
-If you want, only some contaniers will be monitorized, you mast set `monitorize_always=false`, and set `es.atareao.den.monitorize=true`, in those containers you want monitorize.
-
-By the moment, only container have this attribute. I think in next version I can implement this feature for other Docker objects.
-
-### Configuration
+### Docker CLI
 
 ```bash
+docker run -d \
+  --name den \
+  --init \
+  --restart unless-stopped \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v $(pwd)/config.yml:/app/config.yml \
+  -e RUST_LOG=debug \
+  atareao/den:latest
+```
+
+### From Source
+
+```bash
+git clone https://github.com/atareao/den
+cd den
+cargo build --release
+./target/release/den
+```
+
+---
+
+## Container Monitoring Labels
+
+Control which containers are monitored using Docker labels:
+
+| `monitorize_always` | Label                        | Behavior               |
+|---------------------|------------------------------|------------------------|
+| `true` (default)    | *(no label)*                 | Monitored              |
+| `true`              | `es.atareao.den.monitorize=false` | **Excluded**     |
+| `false`             | *(no label)*                 | **Not monitored**      |
+| `false`             | `es.atareao.den.monitorize=true`  | Monitored          |
+
+```bash
+# Exclude a container from monitoring
+docker run --label es.atareao.den.monitorize=false --rm hello-world
+
+# Only monitor containers with this label (when monitorize_always=false)
+docker run --label es.atareao.den.monitorize=true --rm hello-world
+```
+
+---
+
+## Configuration
+
+Full configuration reference in [`config.sample.yml`](./config.sample.yml):
+
+```yaml
 settings:
-  # if `monitorize_always=true` all container are monitorized except has the
-  # label `es.atareao.den.monitorize=false`
-  # if `monitorize_always=false` only container with the following label
-  # `es.atareao.den.monitorize=true` will be monitorized
   monitorize_always: true
 
 objects:
-  #  https://docs.docker.com/engine/reference/commandline/events/
   - name: container
     monitorize: true
-    # attach, commit, copy, create, destroy, detach, die, exec_create,
-    # exec_detach, exec_die, exec_start, export, health_status, kill, oom,
-    # pause, rename, resize, restart, start, stop, top, unpause, update
     events:
-      - name: 'health_status: unhealthy'
-        message: "📦🤒 Container unhealty
-            DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            Hostname: {{hostname}}\n
-            Container: {{container}}\n
-            Image: {{image}}"
+      - name: "health_status: unhealthy"
+        message: "📦🤒 Container unhealthy\nDateTime: {{ timestamp|datetimeformat(format='iso') }}\nHostname: {{hostname}}\nContainer: {{container}}\nImage: {{image}}"
       - name: destroy
-        message: "📦💥 Destroyed container\n
-            DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            Hostname: {{hostname}}\n
-            Container: {{container}}\n
-            Image: {{image}}"
+        message: "📦💥 Destroyed container\nDateTime: {{ timestamp|datetimeformat(format='iso') }}\nHostname: {{hostname}}\nContainer: {{container}}\nImage: {{image}}"
       - name: stop
-        message: "📦✋ Stopped container
-            DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            Hostname: **{{hostname}}**\n
-            Container: **{{container}}**\n
-            Image: **{{image}}**"
+        message: "📦✋ Stopped container\nDateTime: {{ timestamp|datetimeformat(format='iso') }}\nHostname: **{{hostname}}**\nContainer: **{{container}}**\nImage: **{{image}}**"
       - name: start
-        message: "📦🏁 Started container\n
-            DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            Hostname: **{{hostname}}**\n
-            Container: **{{container}}**\n
-            Image: **{{image}}**"
+        message: "📦🏁 Started container\nDateTime: {{ timestamp|datetimeformat(format='iso') }}\nHostname: **{{hostname}}**\nContainer: **{{container}}**\nImage: **{{image}}**"
       - name: create
-        message: "### 📦🆕 Created container\n
-            * DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            * Hostname: **{{hostname}}**\n
-            * Container: **{{container}}**\n
-            * Image: **{{image}}**"
+        message: "### 📦🆕 Created container\n* DateTime: {{ timestamp|datetimeformat(format='iso') }}\n* Hostname: **{{hostname}}**\n* Container: **{{container}}**\n* Image: **{{image}}**"
       - name: die
-        message: "📦☠️  Died container\n
-            DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            Hostname: {{hostname}}\n
-            Container: {{container}}\n
-            Image: {{image}}"
+        message: "📦☠️ Died container\nDateTime: {{ timestamp|datetimeformat(format='iso') }}\nHostname: {{hostname}}\nContainer: {{container}}\nImage: {{image}}"
   - name: image
     monitorize: true
-    # delete, import, load, pull, push, save, tag, untag
     events:
       - name: delete
         message: Deleted image
-  - name: plugin
-    monitorize: false
-    # enable, disable, install, remove
-    events: []
   - name: volume
     monitorize: true
-    # create, destroy, mount, unmount
     events:
       - name: destroy
-        message: "🥃💥 Volume destroyed
-            DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            Hostname: {{hostname}}\n
-            Volume: {{volume}}"
+        message: "🥃💥 Volume destroyed\nDateTime: {{ timestamp|datetimeformat(format='iso') }}\nHostname: {{hostname}}\nVolume: {{volume}}"
       - name: create
-        message: "🥃🆕 Volume created \n
-            DateTime: {{now | date(format='%H:%M:%S %d-%m-%Y', timezone='Europe/Madrid')}}\n
-            Hostname: {{hostname}}\n
-            Volume: {{volume}}"
+        message: "🥃🆕 Volume created\nDateTime: {{now | date(format='%H:%M:%S %d-%m-%Y', timezone='Europe/Madrid')}}\nHostname: {{hostname}}\nVolume: {{volume}}"
   - name: network
     monitorize: true
-    # create, connect, destroy, disconnect, remove
     events:
       - name: destroy
-        message: "🕸️💥 Network destroyed\n
-            DateTime: {{ timestamp|datetimeformat(format='iso') }}\n
-            Hostname: {{hostname}}\n
-            Network: {{network}}"
-  - name: daemon
-    monitorize: false
-    # reload
-    events: []
-  - name: service
-    monitorize: false
-    # create, remove, update
-    events: []
-  - name: node
-    monitorize: false
-    # create, remove, update
-    events: []
-  - name: secret
-    monitorize: false
-    # create, remove, update
-    events: []
-  - name: config
-    monitorize: false
-    # create, remove, update
-    events: []
+        message: "🕸️💥 Network destroyed\nDateTime: {{ timestamp|datetimeformat(format='iso') }}\nHostname: {{hostname}}\nNetwork: {{network}}"
 
-publishers: ## Available publishers
+publishers:
   - service: slack
     enabled: false
     config:
@@ -184,25 +180,25 @@ publishers: ## Available publishers
   - service: mattermost
     enabled: false
     config:
-      url: https://mm.tusitio.como
+      url: https://mm.your-site.com
       token: xxxxxxxxxxxxxxxxxxxx
       channel_id: xxxxxxxxxxxxxxxxxxx
   - service: telegram
     enabled: false
     config:
       url: https://api.telegram.org
-      token:
-      chat_id:
+      token: <BOT_TOKEN>
+      chat_id: <CHAT_ID>
   - service: zinc
     enabled: true
     config:
-      url: https://zincobserve.tusitio.como
+      url: https://zincobserve.your-site.com
       token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       index: docker
   - service: matrix
     enabled: false
     config:
-      url: matrix.tusitio.como
+      url: matrix.your-site.com
       token: xxxxxxxxxxxxxxxxxxxxxxxxxxx
       room: "!xxxxxxxxxxxxxxxxxxxxxxxx"
   - service: mosquitto
@@ -212,7 +208,7 @@ publishers: ## Available publishers
       password: guest
       host: localhost
       port: 1883
-      topic: bonzo/dog
+      topic: docker/events
   - service: rabbitmq
     enabled: false
     config:
@@ -223,205 +219,65 @@ publishers: ## Available publishers
       queue: docker
 ```
 
-### Docker compose
-
-If you want to use DEN with Docker Compose, this is an example,
-
-```bash
-services:
-  den:
-    image: atareao/den:latest
-    container_name: den
-    init: true
-    restart: unless-stopped
-    hostname: co1
-    environment:
-        RUST_LOG: debug
-    volumes:
-      - ./config.yml:/app/config.yml
-      - /var/run/docker.sock:/var/run/docker.sock
-```
-
-
-
-##  Features
-
-|    | Feature          | Description                                                                                                       |
-|----|------------------|-------------------------------------------------------------------------------------------------------------------|
-| ⚙️  | **Architecture** | The project utilizes a containerized architecture with Docker, enabling efficient deployment and scalability.      |
-| 🔩 | **Code Quality** | The codebase maintains high quality standards with clear logic and adherence to Rust best practices.              |
-| 📄 | **Documentation**| The project offers comprehensive documentation, detailing setup instructions, configuration, and usage guidelines.|
-| 🔌 | **Integrations** | Key integrations include Docker for containerization and various messaging platforms for notifications.            |
-| 🧩 | **Modularity**   | The codebase is structured in a modular fashion, promoting code reusability and ease of maintenance.               |
-| 🧪 | **Testing**      | Testing frameworks and tools are not explicitly mentioned in the details provided for the project.                |
-| ⚡️  | **Performance**  | The project aims to achieve efficiency and speed through its Rust implementation and Docker-based deployment.     |
-| 🛡️ | **Security**     | Security measures may include Docker security features and access control mechanisms for monitoring configurations.|
-| 📦 | **Dependencies** | Key dependencies include tokio, reqwest, serde for efficient Rust development, and various Docker-related packages.|
-| 🚀 | **Scalability**  | The use of Docker and a containerized approach suggests good potential for scalability to handle increased loads.    |
-
 ---
 
-##  Repository Structure
+## Message Templates
 
-```sh
-└── den/
-    ├── Cargo.toml
-    ├── Dockerfile
-    ├── LICENSE
-    ├── README.md
-    ├── config.sample.yml
-    ├── docker-compose.yml
-    ├── entrypoint.sh
-    ├── run.sh
-    └── src
-        ├── config.rs
-        ├── error.rs
-        ├── filters.rs
-        ├── main.rs
-        ├── object.rs
-        └── publisher.rs
+Messages use [MiniJinja](https://github.com/mitsuhiko/minijinja) templates with these variables:
+
+| Variable      | Description                  | Available For       |
+|---------------|------------------------------|---------------------|
+| `{{hostname}}`| Docker host hostname         | All objects         |
+| `{{timestamp}}`| Unix timestamp of the event | All objects         |
+| `{{id}}`      | Event actor ID               | All objects         |
+| `{{container}}`| Container name              | Container events    |
+| `{{image}}`   | Container image              | Container events    |
+| `{{volume}}`  | Volume name                  | Volume events       |
+| `{{network}}` | Network name                 | Network events      |
+| `{{type}}`    | Network type                 | Network events      |
+
+A custom `datetimeformat` filter is available:
+
+```
+{{ timestamp|datetimeformat(format='iso') }}
+{{ timestamp|datetimeformat(format='%H:%M:%S', timezone='Europe/Madrid') }}
 ```
 
 ---
 
-##  Modules
+## Repository Structure
 
-<details closed><summary>.</summary>
-
-| File                                                                                | Summary                                                                                                                                                                                                                                                                                    |
-| ---                                                                                 | ---                                                                                                                                                                                                                                                                                        |
-| [run.sh](https://github.com/atareao/den/blob/master/run.sh)                         | Initiate containerized Den service using run.sh to facilitate environment setup with necessary configurations and components.                                                                                                                                                              |
-| [docker-compose.yml](https://github.com/atareao/den/blob/master/docker-compose.yml) | Defines Docker service configuration for den image with restart policy, logging level, and volume mounts in the repository architecture.                                                                                                                                                   |
-| [Cargo.toml](https://github.com/atareao/den/blob/master/Cargo.toml)                 | Implements dependencies in Cargo.toml for den project, managing packages like tokio, reqwest, serde for efficient Rust development.                                                                                                                                                        |
-| [Dockerfile](https://github.com/atareao/den/blob/master/Dockerfile)                 | Builds a Rust application container using multi-stage Docker within the repositorys den' directory. Inherits required dependencies and sets up a compact Alpine-based image for deployment. Simplifies the distribution process by managing build artifacts efficiently.                   |
-| [config.sample.yml](https://github.com/atareao/den/blob/master/config.sample.yml)   | Defines monitoring settings for various Docker objects with customizable event messages. Specifies publishers for notifications via Slack, Discord, Mattermost, Telegram, Zinc, Matrix, Mosquitto, and RabbitMQ, enhancing observability in the comprehensive Den repository architecture. |
-| [entrypoint.sh](https://github.com/atareao/den/blob/master/entrypoint.sh)           | Initialize user and group, set ownership, and execute commands securely for the Den project through the entrypoint shell script.                                                                                                                                                           |
-
-</details>
-
-<details closed><summary>src</summary>
-
-| File                                                                        | Summary                                                                                                                                                                                                                                                                      |
-| ---                                                                         | ---                                                                                                                                                                                                                                                                          |
-| [main.rs](https://github.com/atareao/den/blob/master/src/main.rs)           | Processes Docker events based on configuration, extracting relevant information and sending messages to enabled publishers. Loads configuration, initializes Docker, and listens for events. Logs event details, handles monitorization logic, and triggers message posting. |
-| [error.rs](https://github.com/atareao/den/blob/master/src/error.rs)         | Defines a custom error struct with a message, implementing display and error traits for the repositorys error handling.                                                                                                                                                      |
-| [filters.rs](https://github.com/atareao/den/blob/master/src/filters.rs)     | Implements a datetime formatting filter for Unix timestamps or ISO 8601 strings. Parses dates and times with timezone support. Takes formatting and timezone as arguments, defaults from context variables.                                                                  |
-| [object.rs](https://github.com/atareao/den/blob/master/src/object.rs)       | Defines Docker event and object structs with parsing logic for event message templates and rendering based on event type. Handles different event scenarios with contextual data and filtering rules from the parent repositorys architecture.                               |
-| [publisher.rs](https://github.com/atareao/den/blob/master/src/publisher.rs) | Implements publisher services for various platforms, enabling message posting via RabbitMQ, MQTT, Zinc, Telegram, and Mattermost. Posts messages utilizing specific configurations for each platform.                                                                        |
-| [config.rs](https://github.com/atareao/den/blob/master/src/config.rs)       | Ability to check if monitoring is always enabled.                                                                                                                                                                                                                            |
-
-</details>
+```
+den/
+├── Cargo.toml          # Rust dependencies & metadata
+├── Dockerfile          # Multi-stage Docker build
+├── config.sample.yml   # Configuration reference
+├── docker-compose.yml  # Compose example
+├── entrypoint.sh       # Container entrypoint
+├── run.sh              # Init helper
+└── src/
+    ├── main.rs         # Event loop & orchestration
+    ├── config.rs       # YAML config parser
+    ├── object.rs       # Docker event/object models
+    ├── publisher.rs    # Publisher implementations
+    ├── filters.rs      # Template filters (datetime)
+    └── error.rs        # Custom error types
+```
 
 ---
 
-##  Getting Started
+## Contributing
 
-**System Requirements:**
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-* **Rust**: `version x.y.z`
-
-###  Installation
-
-<h4>From <code>source</code></h4>
-
-> 1. Clone the den repository:
->
-> ```console
-> $ git clone https://github.com/atareao/den
-> ```
->
-> 2. Change to the project directory:
-> ```console
-> $ cd den
-> ```
->
-> 3. Install the dependencies:
-> ```console
-> $ cargo build
-> ```
-
-###  Usage
-
-<h4>From <code>source</code></h4>
-
-> Run den using the command below:
-> ```console
-> $ cargo run
-> ```
-
-###  Tests
-
-> Run the test suite using the command below:
-> ```console
-> $ cargo test
-> ```
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing`)
+3. Commit your changes
+4. Push to the branch (`git push origin feature/amazing`)
+5. Open a Pull Request
 
 ---
 
-##  Project Roadmap
+## License
 
-- [X] `► INSERT-TASK-1`
-- [ ] `► INSERT-TASK-2`
-- [ ] `► ...`
-
----
-
-##  Contributing
-
-Contributions are welcome! Here are several ways you can contribute:
-
-- **[Report Issues](https://github.com/atareao/den/issues)**: Submit bugs found or log feature requests for the `den` project.
-- **[Submit Pull Requests](https://github.com/atareao/den/blob/main/CONTRIBUTING.md)**: Review open PRs, and submit your own PRs.
-- **[Join the Discussions](https://github.com/atareao/den/discussions)**: Share your insights, provide feedback, or ask questions.
-
-<details closed>
-<summary>Contributing Guidelines</summary>
-
-1. **Fork the Repository**: Start by forking the project repository to your github account.
-2. **Clone Locally**: Clone the forked repository to your local machine using a git client.
-   ```sh
-   git clone https://github.com/atareao/den
-   ```
-3. **Create a New Branch**: Always work on a new branch, giving it a descriptive name.
-   ```sh
-   git checkout -b new-feature-x
-   ```
-4. **Make Your Changes**: Develop and test your changes locally.
-5. **Commit Your Changes**: Commit with a clear message describing your updates.
-   ```sh
-   git commit -m 'Implemented new feature x.'
-   ```
-6. **Push to github**: Push the changes to your forked repository.
-   ```sh
-   git push origin new-feature-x
-   ```
-7. **Submit a Pull Request**: Create a PR against the original project repository. Clearly describe the changes and their motivations.
-8. **Review**: Once your PR is reviewed and approved, it will be merged into the main branch. Congratulations on your contribution!
-</details>
-
-<details closed>
-<summary>Contributor Graph</summary>
-<br>
-<p align="center">
-   <a href="https://github.com{/atareao/den/}graphs/contributors">
-      <img src="https://contrib.rocks/image?repo=atareao/den">
-   </a>
-</p>
-</details>
-
----
-
-##  License
-
-This project is protected under the [SELECT-A-LICENSE](https://choosealicense.com/licenses) License. For more details, refer to the [LICENSE](https://choosealicense.com/licenses/) file.
-
----
-
-##  Acknowledgments
-
-- List any resources, contributors, inspiration, etc. here.
-
-[**Return**](#-overview)
-
----
-
+[MIT](./LICENSE) &mdash; Copyright &copy; 2022 Lorenzo Carbonell

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,3 +41,98 @@ impl Configuration {
         self.settings.monitorize_always
     }
 }
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    const VALID_YAML: &str = r#"
+settings:
+  monitorize_always: true
+  docker_uri: unix:///var/run/docker.sock
+objects:
+  - name: container
+    monitorize: true
+    events:
+      - name: start
+        message: "{{container}} started"
+  - name: volume
+    monitorize: false
+    events: []
+publishers:
+  - service: telegram
+    enabled: false
+    config:
+      token: test
+      chat_id: test
+"#;
+
+    #[test]
+    fn new_returns_configuration_when_valid_yaml() {
+        let config = Configuration::new(VALID_YAML).unwrap();
+        assert!(config.settings.monitorize_always);
+        assert_eq!(config.settings.docker_uri, "unix:///var/run/docker.sock");
+    }
+
+    #[test]
+    fn new_returns_error_when_invalid_yaml() {
+        let result = Configuration::new("invalid: [yaml: broken");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_object_returns_some_when_found_and_monitorized() {
+        let config = Configuration::new(VALID_YAML).unwrap();
+        let obj = config.get_object("container");
+        assert!(obj.is_some());
+        assert_eq!(obj.unwrap().name, "container");
+    }
+
+    #[test]
+    fn get_object_returns_none_when_not_found() {
+        let config = Configuration::new(VALID_YAML).unwrap();
+        assert!(config.get_object("nonexistent").is_none());
+    }
+
+    #[test]
+    fn get_object_returns_none_when_not_monitorized() {
+        let config = Configuration::new(VALID_YAML).unwrap();
+        assert!(config.get_object("volume").is_none());
+    }
+
+    #[test]
+    fn get_docker_uri_returns_configured_uri() {
+        let config = Configuration::new(VALID_YAML).unwrap();
+        assert_eq!(config.get_docker_uri(), "unix:///var/run/docker.sock");
+    }
+
+    #[test]
+    fn get_docker_uri_returns_default_when_not_set() {
+        let yaml = r#"
+settings:
+  monitorize_always: false
+objects: []
+publishers: []
+"#;
+        let config = Configuration::new(yaml).unwrap();
+        assert_eq!(config.get_docker_uri(), "/var/run/docker.sock");
+    }
+
+    #[test]
+    fn is_monitorize_always_returns_true_when_set() {
+        let config = Configuration::new(VALID_YAML).unwrap();
+        assert!(config.is_monitorize_always());
+    }
+
+    #[test]
+    fn is_monitorize_always_returns_false_when_unset() {
+        let yaml = r#"
+settings:
+  monitorize_always: false
+objects: []
+publishers: []
+"#;
+        let config = Configuration::new(yaml).unwrap();
+        assert!(!config.is_monitorize_always());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,3 +21,27 @@ impl fmt::Display for CustomError {
 }
 
 impl error::Error for CustomError {}
+
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_error_with_message() {
+        let err = CustomError::new("test error".to_string());
+        assert_eq!(err.to_string(), "Error: test error");
+    }
+
+    #[test]
+    fn display_formats_error_correctly() {
+        let err = CustomError::new("something failed".to_string());
+        assert_eq!(format!("{}", err), "Error: something failed");
+    }
+
+    #[test]
+    fn error_trait_is_implemented() {
+        fn takes_error(_: &dyn error::Error) {}
+        let err = CustomError::new("implemented".to_string());
+        takes_error(&err);
+    }
+}

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -189,3 +189,95 @@ pub fn datetimeformat(state: &State, value: Value, kwargs: Kwargs) -> Result<Str
             Error::new(ErrorKind::InvalidOperation, "failed to format date").with_source(err)
         })
 }
+
+#[cfg(test)]
+mod filters_tests {
+    use super::*;
+    use minijinja::Environment;
+
+    fn setup_env() -> Environment<'static> {
+        let mut env = Environment::new();
+        env.add_filter("datetimeformat", datetimeformat);
+        env
+    }
+
+    #[test]
+    fn datetimeformat_formats_iso() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000|datetimeformat(format='iso') }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "2024-05-06T12:53:20+00:00");
+    }
+
+    #[test]
+    fn datetimeformat_formats_short() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000|datetimeformat(format='short') }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "2024-05-06 12:53");
+    }
+
+    #[test]
+    fn datetimeformat_formats_medium() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000|datetimeformat(format='medium') }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "May 6 2024 12:53");
+    }
+
+    #[test]
+    fn datetimeformat_formats_long() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000|datetimeformat(format='long') }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "May 6 2024 12:53:20");
+    }
+
+    #[test]
+    fn datetimeformat_formats_unix() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000|datetimeformat(format='unix') }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "1715000000");
+    }
+
+    #[test]
+    fn datetimeformat_uses_default_format_when_omitted() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000|datetimeformat }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "May 6 2024 12:53");
+    }
+
+    #[test]
+    fn datetimeformt_handles_custom_format_string() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000|datetimeformat(format='[year]-[month]-[day]') }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "2024-05-06");
+    }
+
+    #[test]
+    fn datetimeformat_handles_float_timestamp() {
+        let env = setup_env();
+        let template = env
+            .template_from_str("{{ 1715000000.5|datetimeformat(format='unix') }}")
+            .unwrap();
+        let result = template.render(&minijinja::context!()).unwrap();
+        assert_eq!(result, "1715000000");
+    }
+}

--- a/src/object.rs
+++ b/src/object.rs
@@ -73,3 +73,202 @@ impl DockerObject {
         }
     }
 }
+
+#[cfg(test)]
+mod object_tests {
+    use super::*;
+    use std::collections::HashMap;
+    use docker_api::models::{EventMessage, EventActor};
+
+    fn make_container_object() -> DockerObject {
+        DockerObject {
+            name: "container".to_string(),
+            monitorize: true,
+            events: vec![DockerEvent {
+                name: "start".to_string(),
+                message: "{{container}} started on {{hostname}}".to_string(),
+            }],
+        }
+    }
+
+    fn make_network_object() -> DockerObject {
+        DockerObject {
+            name: "network".to_string(),
+            monitorize: true,
+            events: vec![DockerEvent {
+                name: "create".to_string(),
+                message: "Network {{network}} created on {{hostname}}".to_string(),
+            }],
+        }
+    }
+
+    fn make_volume_object() -> DockerObject {
+        DockerObject {
+            name: "volume".to_string(),
+            monitorize: true,
+            events: vec![DockerEvent {
+                name: "create".to_string(),
+                message: "Volume {{volume}} created with {{driver}}".to_string(),
+            }],
+        }
+    }
+
+    fn make_event_message(
+        type_: &str,
+        action: &str,
+        attrs: Vec<(&str, &str)>,
+        id: &str,
+        time: i64,
+    ) -> EventMessage {
+        let attributes: HashMap<String, String> = attrs
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        EventMessage {
+            type_: Some(type_.to_string()),
+            action: Some(action.to_string()),
+            actor: Some(EventActor {
+                id: Some(id.to_string()),
+                attributes: Some(attributes),
+            }),
+            time: Some(time),
+            time_nano: None,
+            scope: None,
+        }
+    }
+
+    #[test]
+    fn get_event_returns_some_when_found() {
+        let obj = make_container_object();
+        let event = obj.get_event("start");
+        assert!(event.is_some());
+        assert_eq!(event.unwrap().name, "start");
+    }
+
+    #[test]
+    fn get_event_returns_none_when_not_found() {
+        let obj = make_container_object();
+        assert!(obj.get_event("destroy").is_none());
+    }
+
+    #[test]
+    fn parse_renders_container_template_with_all_variables() {
+        let obj = make_container_object();
+        let docker_event = DockerEvent {
+            name: "start".to_string(),
+            message: "{{container}} started on {{hostname}}".to_string(),
+        };
+        let event = make_event_message(
+            "container",
+            "start",
+            vec![("name", "my-nginx"), ("image", "nginx:latest")],
+            "abc123",
+            1234567890,
+        );
+        let result = obj.parse(&docker_event, event, "myserver", true);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "my-nginx started on myserver");
+    }
+
+    #[test]
+    fn parse_renders_network_template_with_all_variables() {
+        let obj = make_network_object();
+        let docker_event = DockerEvent {
+            name: "create".to_string(),
+            message: "Network {{network}} created on {{hostname}}".to_string(),
+        };
+        let event = make_event_message(
+            "network",
+            "create",
+            vec![("type", "bridge"), ("name", "my-network")],
+            "abc123",
+            1234567890,
+        );
+        let result = obj.parse(&docker_event, event, "myserver", true);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Network my-network created on myserver");
+    }
+
+    #[test]
+    fn parse_renders_volume_template_with_all_variables() {
+        let obj = make_volume_object();
+        let docker_event = DockerEvent {
+            name: "create".to_string(),
+            message: "Volume {{volume}} created with {{driver}}".to_string(),
+        };
+        let event = make_event_message(
+            "volume",
+            "create",
+            vec![("driver", "local"), ("name", "my-volume")],
+            "abc123",
+            1234567890,
+        );
+        let result = obj.parse(&docker_event, event, "myserver", true);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Volume my-volume created with local");
+    }
+
+    #[test]
+    fn parse_returns_error_for_unknown_object_type() {
+        let obj = DockerObject {
+            name: "unknown".to_string(),
+            monitorize: true,
+            events: vec![DockerEvent {
+                name: "test".to_string(),
+                message: "test".to_string(),
+            }],
+        };
+        let docker_event = DockerEvent {
+            name: "test".to_string(),
+            message: "test".to_string(),
+        };
+        let event = make_event_message("unknown", "test", vec![("name", "test")], "abc123", 0);
+        let result = obj.parse(&docker_event, event, "host", true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_uses_id_as_name_when_name_attribute_missing() {
+        let obj = make_container_object();
+        let docker_event = DockerEvent {
+            name: "start".to_string(),
+            message: "{{container}}".to_string(),
+        };
+        let event = make_event_message(
+            "container",
+            "start",
+            vec![("image", "nginx:latest")],
+            "abc123def456",
+            1234567890,
+        );
+        let result = obj.parse(&docker_event, event, "myserver", true);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "abc123def456");
+    }
+
+    #[test]
+    fn parse_uses_datetimeformat_filter() {
+        let obj = DockerObject {
+            name: "container".to_string(),
+            monitorize: true,
+            events: vec![DockerEvent {
+                name: "start".to_string(),
+                message: "{{ timestamp|datetimeformat(format='iso') }}".to_string(),
+            }],
+        };
+        let docker_event = DockerEvent {
+            name: "start".to_string(),
+            message: "{{ timestamp|datetimeformat(format='iso') }}".to_string(),
+        };
+        let event = make_event_message(
+            "container",
+            "start",
+            vec![("name", "test"), ("image", "test:latest")],
+            "abc123",
+            1715000000,
+        );
+        let result = obj.parse(&docker_event, event, "host", true);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "2024-05-06T12:53:20+00:00");
+    }
+}

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -199,7 +199,7 @@ impl Publisher{
         let base_url = self.config.get("url").unwrap();
         let now = SystemTime::now();
         let ts = now.duration_since(UNIX_EPOCH).expect("Time went backwrds").as_secs();
-        let url = format!("https://{}/_matrix/client/v3/rooms/{}:{}/send/m.room.message/{}", base_url, room, base_url, ts);
+        let url = format!("https://{}/_matrix/client/v3/rooms/{}/send/m.room.message/{}", base_url, room, ts);
         let mut html = markdown::to_html(message);
         html = html[..html.len()-1].to_string();
         let body = json!({


### PR DESCRIPTION
## Changes

- ✅ **test**: add 28 unit tests across config, error, object and filters modules
- 👷 **ci**: add Docker image push to `ghcr.io/atareao/den` on release (tagged with version and latest)
- 📝 **docs**: rewrite README with badges, quick start guide, consolidated config reference
- ⬆️ **deps**: bump tokio, reqwest, minijinja, tracing and time dependencies
- 🔧 **chore**: migrate justfile from docker to podman
- 🐛 **fix**: correct Matrix publisher URL template (removed duplicate base_url)

All 28 tests pass with `cargo test`.